### PR TITLE
Support ruleset as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,32 @@ This will hopefully put you in a position where your codebase will become more c
            phpcs-diff - detect violations based on a git diff
     
     SYNOPSIS
-           phpcs-diff [BASE_BRANCH]... [OPTION]...
+           phpcs-diff [-v] [--ruleset=PSR2] [BASE_BRANCH] [CURRENT_BRANCH]
     
     OPTIONS
            Here is a (very) short summary of the options available in phpcs-diff.
            
            -v
                   increase verbosity
+           --ruleset
+                  defines which php-cs ruleset to use (for example: PSR1, PSR12, ...)
                                    
 Basic example
 
 ```shell
-phpcs-diff develop -v
+phpcs-diff -v origin/develop develop
 ```
 
-Where the current branch you are on is the branch you are comparing with, and `develop` is the base branch. In this example, `phpcs-diff` would run the following diff statement:
+Where `origin/develop` is the base branch comparing with and `develop` is the current branch.
 
 ```shell
-git diff my-current-branch develop
+git diff origin/develop develop
+```
+
+You can check current unstaged files with:
+
+```shell
+phpcs-diff
 ```
 
 ## Installation
@@ -67,7 +75,7 @@ You can also download the `phpcs-diff` source and create a symlink to your `/usr
     git clone https://github.com/olivertappin/phpcs-diff.git
     ln -s phpcs-diff/bin/phpcs-diff /usr/bin/phpcs-diff
     cd /var/www/project
-    phpcs-diff master -v
+    phpcs-diff -v origin/master master
 
 ## Requirements
 

--- a/src/PhpcsDiff.php
+++ b/src/PhpcsDiff.php
@@ -61,10 +61,15 @@ class PhpcsDiff
 
         $this->baseBranch = $this->getArgument(1, '');
         $this->currentBranch = $this->getArgument(2, '');
+
         if ($this->isVerbose) {
-            $this->climate->comment(
-                'Comparing branch: "' . $this->baseBranch . '" against: "' . $this->currentBranch . '"'
-            );
+            if (!$this->baseBranch && !$this->currentBranch) {
+                $this->climate->comment("Comparing unstaged changes.");
+            } else {
+                $this->climate->comment(
+                    'Comparing branch: "' . $this->baseBranch . '" against: "' . $this->currentBranch . '"'
+                );
+            }
         }
     }
 

--- a/src/PhpcsDiff.php
+++ b/src/PhpcsDiff.php
@@ -59,8 +59,8 @@ class PhpcsDiff
 
         $this->ruleset = $this->getOption('--ruleset', self::DEFAULT_RULESET);
 
-        $this->baseBranch = $this->getArgument(1, '');
-        $this->currentBranch = $this->getArgument(2, '');
+        $this->baseBranch = $this->getArgument(0, '');
+        $this->currentBranch = $this->getArgument(1, '');
 
         if ($this->isVerbose) {
             if (!$this->baseBranch && !$this->currentBranch) {
@@ -78,6 +78,7 @@ class PhpcsDiff
         $arguments = array_filter($this->argv, function ($val) {
             return strpos($val, '-') === false;
         });
+        $arguments = array_values($arguments);
 
         return isset($arguments[$index]) ? $arguments[$index] : $default;
     }


### PR DESCRIPTION
Added support for ruleset option and defining branches

- Add support for passing ruleset as option/argument

Facilitates working with custom ruleset / experiment on rules.

- Add support for passing branches (base and current) as arguments

Now it's feasible to run php-cs / php-cs-diff against unstaged changes (neat) and customize branching options.

- Added helper methods to handle flags, options and arguments
- Remove usage of ngettext as extension may not be present and it's overkill

- Remove usage of grep binary and use preg_* extension instead
