### PR TITLE
PHP version and other upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .idea
 vendor
+.phpunit.cache
+coverage.clover

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -25,7 +25,7 @@ tools:
     php_code_coverage: true
     php_code_sniffer:
         config:
-            standard: PSR2
+            standard: PSR12
         filter:
             paths: ['src']
     php_loc:

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,1 @@
-preset: psr2
+preset: psr12

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: php
 
-dist: trusty
+dist: xenial
 
 sudo: false
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
   - nightly
 
 matrix:
@@ -16,7 +15,9 @@ matrix:
   - php: nightly
 
 before_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
   - composer update --no-interaction
 
 script:
-  - vendor/bin/phpunit --stop-on-failure
+  - XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover=coverage.clover --stop-on-failure
+  - if [ -f coverage.clover ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi;

--- a/bin/phpcs-diff
+++ b/bin/phpcs-diff
@@ -8,11 +8,18 @@
  */
 
 if (is_file(__DIR__ . '/../../../autoload.php')) {
-    include_once __DIR__ . '/../../../autoload.php';
+    $autoload = __DIR__ . '/../../../autoload.php';
 } elseif (is_file(__DIR__ . '/../autoload.php')) {
-    include_once __DIR__ . '/../autoload.php';
+    $autoload = __DIR__ . '/../autoload.php';
+} elseif (is_file(__DIR__ . '/../vendor/autoload.php')) {
+    $autoload = __DIR__ . '/../vendor/autoload.php';
+}
+
+if (isset($autoload)) {
+    require $autoload;
 } else {
-    include_once 'vendor/autoload.php';
+    echo 'Can not find autoloader, did you run composer? ' . __DIR__;
+    die(1);
 }
 
 $climate = new League\CLImate\CLImate();

--- a/composer.json
+++ b/composer.json
@@ -2,12 +2,15 @@
     "name": "olivertappin/phpcs-diff",
     "description": "Detects violations of a defined coding standard based on a git diff.",
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.3 || ^8.0",
+        "ext-json": "*",
+        "ext-gettext": "*",
         "squizlabs/php_codesniffer": "*",
         "league/climate": "^3.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.16"
+        "phpunit/phpunit": "^7.5.20 || ^8.5.21 || ^9.5.10",
+        "phpunit/php-code-coverage": "^9.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "ext-gettext": "*",
-        "squizlabs/php_codesniffer": "*",
+        "squizlabs/php_codesniffer": "^3.5.7",
         "league/climate": "^3.4"
     },
     "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
     <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
+        <testsuite name="default">
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -51,7 +51,7 @@ class Filter
     /**
      * @return $this
      */
-    public function filter()
+    public function filter(): Filter
     {
         foreach ($this->unfilteredData as $key => $item) {
             foreach ($this->rules as $rule) {
@@ -70,7 +70,7 @@ class Filter
     /**
      * @return array
      */
-    public function getFilteredData()
+    public function getFilteredData(): array
     {
         return $this->filteredData;
     }
@@ -78,7 +78,7 @@ class Filter
     /**
      * @return array
      */
-    public function getContaminatedData()
+    public function getContaminatedData(): array
     {
         return $this->contaminatedData;
     }

--- a/src/Filter/Rule/FileRule.php
+++ b/src/Filter/Rule/FileRule.php
@@ -3,13 +3,14 @@
 namespace PhpcsDiff\Filter\Rule;
 
 use PhpcsDiff\Filter\Rule\Exception\InvalidArgumentException;
+use PhpcsDiff\Filter\Rule\Exception\RuleException;
 use PhpcsDiff\Filter\Rule\Exception\RuntimeException;
 
 class FileRule implements RuleInterface
 {
     /**
      * @param mixed $data
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @throws RuleException
      */
     public function __invoke($data)
     {

--- a/src/Filter/Rule/HasMessagesRule.php
+++ b/src/Filter/Rule/HasMessagesRule.php
@@ -3,12 +3,13 @@
 namespace PhpcsDiff\Filter\Rule;
 
 use PhpcsDiff\Filter\Rule\Exception\InvalidArgumentException;
+use PhpcsDiff\Filter\Rule\Exception\RuleException;
 
 class HasMessagesRule implements RuleInterface
 {
     /**
      * @param mixed $data
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @throws RuleException
      */
     public function __invoke($data)
     {

--- a/src/Filter/Rule/PhpFileRule.php
+++ b/src/Filter/Rule/PhpFileRule.php
@@ -2,13 +2,14 @@
 
 namespace PhpcsDiff\Filter\Rule;
 
+use PhpcsDiff\Filter\Rule\Exception\RuleException;
 use PhpcsDiff\Filter\Rule\Exception\RuntimeException;
 
 class PhpFileRule extends FileRule
 {
     /**
      * @param mixed $data
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @throws RuleException
      */
     public function __invoke($data)
     {

--- a/src/Mapper/PhpcsViolationsMapper.php
+++ b/src/Mapper/PhpcsViolationsMapper.php
@@ -18,7 +18,7 @@ class PhpcsViolationsMapper implements MapperInterface
      * @param array $changedLinesPerFile
      * @param string $currentDirectory
      */
-    public function __construct(array $changedLinesPerFile, $currentDirectory)
+    public function __construct(array $changedLinesPerFile, string $currentDirectory)
     {
         $this->changedLinesPerFile = $changedLinesPerFile;
         $this->currentDirectory = $currentDirectory;
@@ -28,7 +28,7 @@ class PhpcsViolationsMapper implements MapperInterface
      * @param array $data
      * @return array
      */
-    public function map(array $data)
+    public function map(array $data): array
     {
         $mappedData = [];
 

--- a/src/PhpcsDiff.php
+++ b/src/PhpcsDiff.php
@@ -65,7 +65,6 @@ class PhpcsDiff
 
         if (empty($this->currentBranch)) {
             $this->error('Unable to get <bold>current</bold> branch.');
-            return;
         }
     }
 
@@ -73,7 +72,7 @@ class PhpcsDiff
      * @param string $flag
      * @return bool
      */
-    protected function isFlagSet($flag)
+    protected function isFlagSet(string $flag)
     {
         $isFlagSet = false;
         $argv = $this->argv;
@@ -93,19 +92,15 @@ class PhpcsDiff
     /**
      * @param int $exitCode
      */
-    protected function setExitCode($exitCode)
+    protected function setExitCode(int $exitCode)
     {
-        if (!is_int($exitCode)) {
-            throw new \UnexpectedValueException('The exit code provided is not a valid integer.');
-        }
-
         $this->exitCode = $exitCode;
     }
 
     /**
      * @return int
      */
-    public function getExitCode()
+    public function getExitCode(): int
     {
         return $this->exitCode;
     }
@@ -114,7 +109,7 @@ class PhpcsDiff
      * @todo Automatically look at server envs for the travis base branch, if not provided?
      * @todo Define custom ruleset from command line argv for runPhpcs()
      */
-    public function run()
+    public function run(): void
     {
         try {
             $filter = new Filter([new PhpFileRule()], $this->getChangedFiles());
@@ -192,7 +187,7 @@ class PhpcsDiff
      * @param string $ruleset
      * @return mixed
      */
-    protected function runPhpcs(array $files = [], $ruleset = 'ruleset.xml')
+    protected function runPhpcs(array $files = [], string $ruleset = 'ruleset.xml')
     {
         $exec = 'vendor/bin/phpcs';
 
@@ -201,6 +196,8 @@ class PhpcsDiff
         } elseif (is_file(__DIR__ . '/../bin/phpcs')) {
             $exec = realpath(__DIR__ . '/../bin/phpcs');
         }
+
+        $exec = PHP_BINARY . ' ' . $exec;
 
         return json_decode(
             shell_exec($exec . ' --report=json --standard=' . $ruleset . ' ' . implode(' ', $files)),
@@ -211,7 +208,7 @@ class PhpcsDiff
     /**
      * @param array $output
      */
-    protected function outputViolations(array $output)
+    protected function outputViolations(array $output): void
     {
         $this->climate->flank(strtoupper('Start of phpcs check'), '#', 10)->br();
         $this->climate->out(implode(PHP_EOL, $output));
@@ -225,7 +222,7 @@ class PhpcsDiff
      *
      * @return array
      */
-    protected function getChangedFiles()
+    protected function getChangedFiles(): array
     {
         // Get a list of changed files (not including deleted files)
         $output = shell_exec(
@@ -245,7 +242,7 @@ class PhpcsDiff
      * @param array $files
      * @return array
      */
-    protected function getChangedLinesPerFile(array $files)
+    protected function getChangedLinesPerFile(array $files): array
     {
         $extract = [];
         $pattern = [
@@ -292,7 +289,7 @@ class PhpcsDiff
      * @param string $message
      * @param int $exitCode
      */
-    protected function error($message, $exitCode = 1)
+    protected function error(string $message, int $exitCode = 1): void
     {
         $this->climate->error($message);
         $this->setExitCode($exitCode);

--- a/src/Validator/RuleValidator.php
+++ b/src/Validator/RuleValidator.php
@@ -4,14 +4,14 @@ namespace PhpcsDiff\Validator;
 
 use PhpcsDiff\Filter\Rule\RuleInterface;
 use PhpcsDiff\Validator\Exception\InvalidArgumentException;
+use PhpcsDiff\Validator\Exception\ValidatorException;
 
 class RuleValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @return mixed|void
-     * @throws \PhpcsDiff\Validator\Exception\ValidatorException
+     * @throws ValidatorException
      */
-    public function validate()
+    public function validate(): void
     {
         if (empty($this->data)) {
             throw new InvalidArgumentException('The data provided is empty.');

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -2,13 +2,15 @@
 
 namespace PhpcsDiff\Tests\Filter;
 
+use PhpcsDiff\Filter\Exception\FilterException;
+use PhpcsDiff\Filter\Exception\InvalidRuleException;
 use PhpcsDiff\Filter\Filter;
 use PhpcsDiff\Filter\Rule\FileRule;
 use PhpcsDiff\Tests\TestBase;
 
 class FilterTest extends TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -21,7 +23,7 @@ class FilterTest extends TestBase
         fclose($handle);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 
@@ -35,7 +37,7 @@ class FilterTest extends TestBase
     /**
      * @return array
      */
-    public function unfilteredDataProvider()
+    public function unfilteredDataProvider(): array
     {
         return [
             [
@@ -100,13 +102,15 @@ class FilterTest extends TestBase
     }
 
     /**
-     * @covers Filter::__construct
-     * @expectedException \PhpcsDiff\Filter\Exception\InvalidRuleException
-     * @expectedException \PhpcsDiff\Filter\Exception\FilterException
-     * @throws \PhpcsDiff\Filter\Exception\FilterException
+     * @covers \PhpcsDiff\Filter\Filter::__construct
+     * @covers \PhpcsDiff\Validator\AbstractValidator::__construct
+     * @covers \PhpcsDiff\Validator\RuleValidator::validate
+     * @throws FilterException
      */
-    public function testInvalidRule()
+    public function testInvalidRule(): void
     {
+        $this->expectException(FilterException::class);
+        $this->expectException(InvalidRuleException::class);
         new Filter(
             [
                 new \stdClass(),
@@ -120,10 +124,14 @@ class FilterTest extends TestBase
     }
 
     /**
-     * @covers Filter::filter
-     * @throws \PhpcsDiff\Filter\Exception\FilterException
+     * @covers \PhpcsDiff\Filter\Filter::filter
+     * @covers \PhpcsDiff\Filter\Filter::__construct
+     * @covers \PhpcsDiff\Filter\Rule\FileRule::__invoke
+     * @covers \PhpcsDiff\Validator\AbstractValidator::__construct
+     * @covers \PhpcsDiff\Validator\RuleValidator::validate
+     * @throws FilterException
      */
-    public function testFilterInstance()
+    public function testFilterInstance(): void
     {
         $filter = (new Filter(
             [
@@ -140,17 +148,20 @@ class FilterTest extends TestBase
     }
 
     /**
-     * @covers Filter::__construct
-     * @covers Filter::filter
-     * @covers Filter::getFilteredData
-     * @covers Filter::getContaminatedData
+     * @covers \PhpcsDiff\Filter\Filter::__construct
+     * @covers \PhpcsDiff\Filter\Filter::filter
+     * @covers \PhpcsDiff\Filter\Filter::getFilteredData
+     * @covers \PhpcsDiff\Filter\Filter::getContaminatedData
+     * @covers \PhpcsDiff\Filter\Rule\FileRule::__invoke
+     * @covers \PhpcsDiff\Validator\AbstractValidator::__construct
+     * @covers \PhpcsDiff\Validator\RuleValidator::validate
      * @dataProvider unfilteredDataProvider
      * @param array $unfilteredData
      * @param array $filteredData
      * @param array $contaminatedData
-     * @throws \PhpcsDiff\Filter\Exception\FilterException
+     * @throws FilterException
      */
-    public function testFileFilter(array $unfilteredData, array $filteredData, array $contaminatedData)
+    public function testFileFilter(array $unfilteredData, array $filteredData, array $contaminatedData): void
     {
         $filter = (new Filter(
             [

--- a/tests/Filter/Rule/FileRuleTest.php
+++ b/tests/Filter/Rule/FileRuleTest.php
@@ -39,7 +39,7 @@ class FileRuleTest extends TestBase
      */
     public function testNonString()
     {
-        $this->expectExceptionMessage("The data argument provided is not a string.");
+        $this->expectExceptionMessage('The data argument provided is not a string.');
         $this->expectException(RuleException::class);
         $this->expectException(InvalidArgumentException::class);
         $rule = new FileRule();
@@ -52,7 +52,7 @@ class FileRuleTest extends TestBase
      */
     public function testNonExistentFile()
     {
-        $this->expectExceptionMessage("The file provided does not exist.");
+        $this->expectExceptionMessage('The file provided does not exist.');
         $this->expectException(RuleException::class);
         $this->expectException(RuntimeException::class);
         $rule = new FileRule();
@@ -67,7 +67,7 @@ class FileRuleTest extends TestBase
     {
         $this->expectException(RuntimeException::class);
         $this->expectException(RuleException::class);
-        $this->expectExceptionMessage("The file provided is not a regular file.");
+        $this->expectExceptionMessage('The file provided is not a regular file.');
         $rule = new FileRule();
         $rule('test');
     }

--- a/tests/Filter/Rule/FileRuleTest.php
+++ b/tests/Filter/Rule/FileRuleTest.php
@@ -2,12 +2,15 @@
 
 namespace PhpcsDiff\Tests\Filter\Rule;
 
+use PhpcsDiff\Filter\Rule\Exception\InvalidArgumentException;
+use PhpcsDiff\Filter\Rule\Exception\RuleException;
+use PhpcsDiff\Filter\Rule\Exception\RuntimeException;
 use PhpcsDiff\Filter\Rule\FileRule;
 use PhpcsDiff\Tests\TestBase;
 
 class FileRuleTest extends TestBase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -18,7 +21,7 @@ class FileRuleTest extends TestBase
         fclose(fopen('test.txt', 'wb'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -31,47 +34,47 @@ class FileRuleTest extends TestBase
     }
 
     /**
-     * @covers FileRule::__invoke
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\InvalidArgumentException
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuleException
-     * @expectedExceptionMessage The data argument provided is not a string.
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\FileRule::__invoke
+     * @throws RuleException
      */
     public function testNonString()
     {
+        $this->expectExceptionMessage("The data argument provided is not a string.");
+        $this->expectException(RuleException::class);
+        $this->expectException(InvalidArgumentException::class);
         $rule = new FileRule();
         $rule(null);
     }
 
     /**
-     * @covers FileRule::__invoke
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuntimeException
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuleException
-     * @expectedExceptionMessage The file provided does not exist.
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\FileRule::__invoke
+     * @throws RuleException
      */
     public function testNonExistentFile()
     {
+        $this->expectExceptionMessage("The file provided does not exist.");
+        $this->expectException(RuleException::class);
+        $this->expectException(RuntimeException::class);
         $rule = new FileRule();
         $rule('');
     }
 
     /**
-     * @covers FileRule::__invoke
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuntimeException
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuleException
-     * @expectedExceptionMessage The file provided is not a regular file.
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\FileRule::__invoke
+     * @throws RuleException
      */
     public function testNonFile()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectException(RuleException::class);
+        $this->expectExceptionMessage("The file provided is not a regular file.");
         $rule = new FileRule();
         $rule('test');
     }
 
     /**
-     * @covers PhpFileRule::__invoke
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\FileRule::__invoke
+     * @throws RuleException
      */
     public function testFile()
     {

--- a/tests/Filter/Rule/HasMessagesRuleTest.php
+++ b/tests/Filter/Rule/HasMessagesRuleTest.php
@@ -4,7 +4,6 @@ namespace PhpcsDiff\Tests\Filter\Rule;
 
 use PhpcsDiff\Filter\Rule\Exception\InvalidArgumentException;
 use PhpcsDiff\Filter\Rule\Exception\RuleException;
-use PhpcsDiff\Filter\Rule\FileRule;
 use PhpcsDiff\Filter\Rule\HasMessagesRule;
 use PhpcsDiff\Tests\TestBase;
 
@@ -18,7 +17,7 @@ class HasMessagesRuleTest extends TestBase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectException(RuleException::class);
-        $this->expectExceptionMessage("The data argument provided has no messages.");
+        $this->expectExceptionMessage('The data argument provided has no messages.');
         $rule = new HasMessagesRule();
         $rule([]);
     }
@@ -31,7 +30,7 @@ class HasMessagesRuleTest extends TestBase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectException(RuleException::class);
-        $this->expectExceptionMessage("The data argument provided has no messages.");
+        $this->expectExceptionMessage('The data argument provided has no messages.');
         $rule = new HasMessagesRule();
         $rule(['messages' => []]);
     }
@@ -44,7 +43,7 @@ class HasMessagesRuleTest extends TestBase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectException(RuleException::class);
-        $this->expectExceptionMessage("The data argument provided has no messages.");
+        $this->expectExceptionMessage('The data argument provided has no messages.');
         $rule = new HasMessagesRule();
         $rule(['messages' => null]);
     }

--- a/tests/Filter/Rule/HasMessagesRuleTest.php
+++ b/tests/Filter/Rule/HasMessagesRuleTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpcsDiff\Tests\Filter\Rule;
 
+use PhpcsDiff\Filter\Rule\Exception\InvalidArgumentException;
+use PhpcsDiff\Filter\Rule\Exception\RuleException;
 use PhpcsDiff\Filter\Rule\FileRule;
 use PhpcsDiff\Filter\Rule\HasMessagesRule;
 use PhpcsDiff\Tests\TestBase;
@@ -9,49 +11,49 @@ use PhpcsDiff\Tests\TestBase;
 class HasMessagesRuleTest extends TestBase
 {
     /**
-     * @covers HasMessagesRule::__invoke
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\InvalidArgumentException
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuleException
-     * @expectedExceptionMessage The data argument provided has no messages.
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\HasMessagesRule::__invoke
+     * @throws RuleException
      */
-    public function testNoMessages()
+    public function testNoMessages(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(RuleException::class);
+        $this->expectExceptionMessage("The data argument provided has no messages.");
         $rule = new HasMessagesRule();
         $rule([]);
     }
 
     /**
-     * @covers HasMessagesRule::__invoke
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\InvalidArgumentException
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuleException
-     * @expectedExceptionMessage The data argument provided has no messages.
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\HasMessagesRule::__invoke
+     * @throws RuleException
      */
-    public function testEmptyMessages()
+    public function testEmptyMessages(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(RuleException::class);
+        $this->expectExceptionMessage("The data argument provided has no messages.");
         $rule = new HasMessagesRule();
         $rule(['messages' => []]);
     }
 
     /**
-     * @covers HasMessagesRule::__invoke
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\InvalidArgumentException
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuleException
-     * @expectedExceptionMessage The data argument provided has no messages.
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\HasMessagesRule::__invoke
+     * @throws RuleException
      */
-    public function testNullMessages()
+    public function testNullMessages(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(RuleException::class);
+        $this->expectExceptionMessage("The data argument provided has no messages.");
         $rule = new HasMessagesRule();
         $rule(['messages' => null]);
     }
 
     /**
-     * @covers FileRule::__invoke
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\HasMessagesRule::__invoke
+     * @throws RuleException
      */
-    public function testMessages()
+    public function testMessages(): void
     {
         $rule = new HasMessagesRule();
         $actual = $rule(['messages' => ['message']]);

--- a/tests/Filter/Rule/PhpFileRuleTest.php
+++ b/tests/Filter/Rule/PhpFileRuleTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpcsDiff\Tests\Filter\Rule;
 
+use PhpcsDiff\Filter\Rule\Exception\RuleException;
+use PhpcsDiff\Filter\Rule\Exception\RuntimeException;
 use PhpcsDiff\Filter\Rule\PhpFileRule;
 use PhpcsDiff\Tests\TestBase;
 
@@ -9,7 +11,7 @@ class PhpFileRuleTest extends TestBase
 {
     protected $handle;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -25,7 +27,7 @@ class PhpFileRuleTest extends TestBase
         fclose($handle);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -40,36 +42,39 @@ class PhpFileRuleTest extends TestBase
     }
 
     /**
-     * @covers PhpFileRule::__invoke
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuntimeException
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuleException
-     * @expectedExceptionMessage The file provided does not have a .php extension.
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\PhpFileRule::__invoke
+     * @covers \PhpcsDiff\Filter\Rule\FileRule::__invoke
+     * @throws RuleException
      */
-    public function testNonPhpFile()
+    public function testNonPhpFile(): void
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectException(RuleException::class);
+        $this->expectExceptionMessage("The file provided does not have a .php extension.");
         $rule = new PhpFileRule();
         $rule('test.txt');
     }
 
     /**
-     * @covers PhpFileRule::__invoke
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuntimeException
-     * @expectedException \PhpcsDiff\Filter\Rule\Exception\RuleException
-     * @expectedExceptionMessage The file provided does not have the text/x-php mime type.
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\PhpFileRule::__invoke
+     * @covers \PhpcsDiff\Filter\Rule\FileRule::__invoke
+     * @throws RuleException
      */
-    public function testIncorrectMimeType()
+    public function testIncorrectMimeType(): void
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectException(RuleException::class);
+        $this->expectExceptionMessage("The file provided does not have the text/x-php mime type.");
         $rule = new PhpFileRule();
         $rule('image.php');
     }
 
     /**
-     * @covers PhpFileRule::__invoke
-     * @throws \PhpcsDiff\Filter\Rule\Exception\RuleException
+     * @covers \PhpcsDiff\Filter\Rule\PhpFileRule::__invoke
+     * @covers \PhpcsDiff\Filter\Rule\FileRule::__invoke
+     * @throws RuleException
      */
-    public function testPhpFile()
+    public function testPhpFile(): void
     {
         $rule = new PhpFileRule();
         $actual = $rule('test.php');

--- a/tests/Filter/Rule/PhpFileRuleTest.php
+++ b/tests/Filter/Rule/PhpFileRuleTest.php
@@ -50,7 +50,7 @@ class PhpFileRuleTest extends TestBase
     {
         $this->expectException(RuntimeException::class);
         $this->expectException(RuleException::class);
-        $this->expectExceptionMessage("The file provided does not have a .php extension.");
+        $this->expectExceptionMessage('The file provided does not have a .php extension.');
         $rule = new PhpFileRule();
         $rule('test.txt');
     }
@@ -64,7 +64,7 @@ class PhpFileRuleTest extends TestBase
     {
         $this->expectException(RuntimeException::class);
         $this->expectException(RuleException::class);
-        $this->expectExceptionMessage("The file provided does not have the text/x-php mime type.");
+        $this->expectExceptionMessage('The file provided does not have the text/x-php mime type.');
         $rule = new PhpFileRule();
         $rule('image.php');
     }

--- a/tests/Mapper/PhpcsViolationsMapperTest.php
+++ b/tests/Mapper/PhpcsViolationsMapperTest.php
@@ -8,10 +8,48 @@ use PhpcsDiff\Tests\TestBase;
 
 class PhpcsViolationsMapperTest extends TestBase
 {
+    private $mappedData1 = [
+        'file.php' => [
+            'messages' => [
+                [
+                    'line' => 100,
+                    'message' => 'This is the message',
+                    'type' => 'ERROR',
+                ]
+            ],
+        ],
+    ];
+
+    private $mappedData2 = [
+        'SomeImportantClass.php' => [
+            'messages' => [
+                [
+                    'line' => 230,
+                    'message' => 'This is the message',
+                    'type' => 'ERROR',
+                ],
+            ],
+        ],
+        'index.php' => [
+            'messages' => [
+                [
+                    'line' => 230,
+                    'message' => 'This is the message',
+                    'type' => 'ERROR',
+                ],
+                [
+                    'line' => 250,
+                    'message' => 'Some other warning',
+                    'type' => 'WARNING',
+                ]
+            ],
+        ],
+    ];
+
     /**
-     * @covers PhpcsOutputMapper::__construct
+     * @covers \PhpcsDiff\Mapper\PhpcsViolationsMapper::__construct
      */
-    public function testMapperInstance()
+    public function testMapperInstance(): void
     {
         $mapper = new PhpcsViolationsMapper([], '');
 
@@ -19,12 +57,69 @@ class PhpcsViolationsMapperTest extends TestBase
     }
 
     /**
-     * @covers PhpcsOutputMapper::map
+     * @covers \PhpcsDiff\Mapper\PhpcsViolationsMapper::__construct
+     * @covers \PhpcsDiff\Mapper\PhpcsViolationsMapper::map
      */
-    public function testEmptyMapper()
+    public function testEmptyMapper(): void
     {
         $mappedData = (new PhpcsViolationsMapper([], ''))->map([]);
 
         $this->assertEmpty($mappedData);
+    }
+
+    /**
+     * @covers \PhpcsDiff\Mapper\PhpcsViolationsMapper::__construct
+     * @covers \PhpcsDiff\Mapper\PhpcsViolationsMapper::map
+     */
+    public function testMapperLineMatch(): void
+    {
+        $changedLinesPerFile = [
+            'file.php' => [
+                100,
+            ]
+        ];
+
+        $mappedData = (new PhpcsViolationsMapper($changedLinesPerFile, ''))->map($this->mappedData1);
+
+        self::assertIsArray($mappedData);
+        self::assertCount(1, $mappedData);
+        self::assertIsString($mappedData[0]);
+        self::assertSame($mappedData[0], 'file.php' . PHP_EOL . ' - Line 100 (ERROR) This is the message' . PHP_EOL);
+    }
+
+    /**
+     * @covers \PhpcsDiff\Mapper\PhpcsViolationsMapper::__construct
+     * @covers \PhpcsDiff\Mapper\PhpcsViolationsMapper::map
+     */
+    public function testMapperNoLineMatch(): void
+    {
+        $changedLinesPerFile = [
+            'file.php' => [
+                101,
+            ]
+        ];
+
+        $mappedData = (new PhpcsViolationsMapper($changedLinesPerFile, ''))->map($this->mappedData1);
+
+        self::assertIsArray($mappedData);
+        self::assertCount(0, $mappedData);
+    }
+
+    /**
+     * @covers \PhpcsDiff\Mapper\PhpcsViolationsMapper::__construct
+     * @covers \PhpcsDiff\Mapper\PhpcsViolationsMapper::map
+     */
+    public function testMapperNoFileMatch(): void
+    {
+        $changedLinesPerFile = [
+            'NonMatchedClass.php' => [
+                101,
+            ]
+        ];
+
+        $mappedData = (new PhpcsViolationsMapper($changedLinesPerFile, ''))->map($this->mappedData2);
+
+        self::assertIsArray($mappedData);
+        self::assertCount(0, $mappedData);
     }
 }

--- a/tests/PhpcsDiffTest.php
+++ b/tests/PhpcsDiffTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace PhpcsDiff\Tests;
+
+use League\CLImate\CLImate;
+use PhpcsDiff\PhpcsDiff;
+use PHPUnit\Framework\TestCase;
+
+class PhpcsDiffTest extends TestCase
+{
+    /**
+     * @var CLImate
+     */
+    private $cliMate;
+
+    protected function setUp(): void
+    {
+        $this->cliMate = $this->createMock(CLImate::class);
+    }
+
+    /**
+     * @covers \PhpcsDiff\PhpcsDiff::__construct
+     * @covers \PhpcsDiff\PhpcsDiff::error
+     * @covers \PhpcsDiff\PhpcsDiff::getExitCode
+     * @covers \PhpcsDiff\PhpcsDiff::isFlagSet
+     * @covers \PhpcsDiff\PhpcsDiff::setExitCode
+     */
+    public function testExitCodeBeforeRun()
+    {
+        $phpcsDiff = new PhpcsDiff([], $this->cliMate);
+
+        self::assertSame(1, $phpcsDiff->getExitCode());
+    }
+
+    /**
+     * @covers \PhpcsDiff\PhpcsDiff::__construct
+     * @covers \PhpcsDiff\PhpcsDiff::error
+     * @covers \PhpcsDiff\PhpcsDiff::getExitCode
+     * @covers \PhpcsDiff\PhpcsDiff::isFlagSet
+     * @covers \PhpcsDiff\PhpcsDiff::setExitCode
+     */
+    public function testPhpcsDiffNoCurrent()
+    {
+        $phpcsDiff = new PhpcsDiff(['fakeBranch'], $this->cliMate);
+
+        self::assertSame(1, $phpcsDiff->getExitCode());
+    }
+
+    /**
+     * @covers \PhpcsDiff\PhpcsDiff::__construct
+     * @covers \PhpcsDiff\PhpcsDiff::error
+     * @covers \PhpcsDiff\PhpcsDiff::getExitCode
+     * @covers \PhpcsDiff\PhpcsDiff::isFlagSet
+     * @covers \PhpcsDiff\PhpcsDiff::setExitCode
+     */
+    public function testVerboseNoCurrent()
+    {
+        $this->cliMate
+            ->expects(self::exactly(2))
+            ->method('__call')
+            ->withConsecutive(
+                ['comment', ['Running in verbose mode.']],
+                ['error', ['Please provide a <bold>base branch</bold> as the first argument.']]
+            );
+        ;
+
+        $phpcsDiff = new PhpcsDiff(['-v', 'fakeBranch'], $this->cliMate);
+
+        self::assertSame(1, $phpcsDiff->getExitCode());
+    }
+}

--- a/tests/Validator/RuleValidatorTest.php
+++ b/tests/Validator/RuleValidatorTest.php
@@ -6,14 +6,16 @@ use PhpcsDiff\Filter\Rule\FileRule;
 use PhpcsDiff\Filter\Rule\HasMessagesRule;
 use PhpcsDiff\Filter\Rule\PhpFileRule;
 use PhpcsDiff\Tests\TestBase;
+use PhpcsDiff\Validator\Exception\InvalidArgumentException;
+use PhpcsDiff\Validator\Exception\ValidatorException;
 use PhpcsDiff\Validator\RuleValidator;
 
 class RuleValidatorTest extends TestBase
 {
     /**
-     * @covers RuleValidator::__construct
+     * @covers \PhpcsDiff\Validator\RuleValidator::__construct
      */
-    public function testRuleValidatorInstance()
+    public function testRuleValidatorInstance(): void
     {
         $actual = new RuleValidator([]);
 
@@ -21,38 +23,43 @@ class RuleValidatorTest extends TestBase
     }
 
     /**
-     * @covers RuleValidator::validate
-     * @expectedException \PhpcsDiff\Validator\Exception\InvalidArgumentException
-     * @expectedException \PhpcsDiff\Validator\Exception\ValidatorException
-     * @expectedExceptionMessage The data provided is empty.
+     * @covers \PhpcsDiff\Validator\RuleValidator::__construct
+     * @covers \PhpcsDiff\Validator\RuleValidator::validate
      */
-    public function testEmptyRuleValidator()
+    public function testEmptyRuleValidator(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage("The data provided is empty.");
         (new RuleValidator([]))->validate();
     }
 
     /**
-     * @covers RuleValidator::validate
-     * @expectedException \PhpcsDiff\Validator\Exception\InvalidArgumentException
-     * @expectedException \PhpcsDiff\Validator\Exception\ValidatorException
-     * @expectedExceptionMessage The data provided is not an array.
+     * @covers \PhpcsDiff\Validator\RuleValidator::__construct
+     * @covers \PhpcsDiff\Validator\RuleValidator::validate
      */
-    public function testNonArrayRuleValidator()
+    public function testNonArrayRuleValidator(): void
     {
+        $this->expectException(ValidatorException::class);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The data provided is not an array.');
         (new RuleValidator('string'))->validate();
     }
 
     /**
-     * @covers RuleValidator::validate
+     * @covers \PhpcsDiff\Validator\RuleValidator::__construct
+     * @covers \PhpcsDiff\Validator\RuleValidator::validate
+     * @throws ValidatorException
      */
-    public function testRuleValidator()
+    public function testRuleValidator(): void
     {
-        $actual = (new RuleValidator([
+        $this->expectNotToPerformAssertions();
+
+        // If this throws an exception, the test will fail
+        (new RuleValidator([
             new FileRule(),
             new PhpFileRule(),
             new HasMessagesRule(),
         ]))->validate();
-
-        $this->assertNull($actual);
     }
 }

--- a/tests/Validator/RuleValidatorTest.php
+++ b/tests/Validator/RuleValidatorTest.php
@@ -30,7 +30,7 @@ class RuleValidatorTest extends TestBase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectException(ValidatorException::class);
-        $this->expectExceptionMessage("The data provided is empty.");
+        $this->expectExceptionMessage('The data provided is empty.');
         (new RuleValidator([]))->validate();
     }
 


### PR DESCRIPTION
- Dropped support for PHP 5.6, 7.0, 7.1, 7.2
- Added Support for PHP 8.0
- Added type hints
- Additional unit tests
- Code coverage updates
- Various other fixes/changes
- Move to PSR12